### PR TITLE
feat: add custom date range support (YYYY-MM-DDtoYYYY-MM-DD)  to search tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ An MCP Server implementation that integrates the [Brave Search API](https://brav
         - pw: Discovered within the last 7 Days.
         - pm: Discovered within the last 31 Days.
         - py: Discovered within the last 365 Days
+        - YYYY-MM-DDtoYYYY-MM-DD: Custom date range (e.g., 2022-04-01to2022-07-30)
 
 - **brave_image_search**
 
@@ -49,6 +50,7 @@ An MCP Server implementation that integrates the [Brave Search API](https://brav
         - pw: Discovered within the last 7 Days.
         - pm: Discovered within the last 31 Days.
         - py: Discovered within the last 365 Days
+        - YYYY-MM-DDtoYYYY-MM-DD: Custom date range (e.g., 2022-04-01to2022-07-30)
 
 - **brave_local_search**
 
@@ -71,6 +73,7 @@ An MCP Server implementation that integrates the [Brave Search API](https://brav
         - pw: Discovered within the last 7 Days.
         - pm: Discovered within the last 31 Days.
         - py: Discovered within the last 365 Days
+        - YYYY-MM-DDtoYYYY-MM-DD: Custom date range (e.g., 2022-04-01to2022-07-30)
 
 ## Configuration
 

--- a/src/tools/BraveNewsSearchTool.ts
+++ b/src/tools/BraveNewsSearchTool.ts
@@ -6,7 +6,10 @@ import { BaseTool } from './BaseTool.js';
 const newsSearchInputSchema = z.object({
   query: z.string().describe('The term to search the internet for news articles, trending topics, or recent events'),
   count: z.number().min(1).max(20).default(10).optional().describe('The number of results to return, minimum 1, maximum 20'),
-  freshness: z.enum(['pd', 'pw', 'pm', 'py'])
+  freshness: z.union([
+    z.enum(['pd', 'pw', 'pm', 'py']),
+    z.string().regex(/^\d{4}-\d{2}-\d{2}to\d{4}-\d{2}-\d{2}$/, 'Date range must be in format YYYY-MM-DDtoYYYY-MM-DD')
+  ])
     .optional()
     .describe(
       `Filters search results by when they were discovered.
@@ -14,7 +17,8 @@ The following values are supported:
 - pd: Discovered within the last 24 hours.
 - pw: Discovered within the last 7 Days.
 - pm: Discovered within the last 31 Days.
-- py: Discovered within the last 365 Days`,
+- py: Discovered within the last 365 Days.
+- YYYY-MM-DDtoYYYY-MM-DD: Custom date range (e.g., 2022-04-01to2022-07-30)`,
     ),
 });
 

--- a/src/tools/BraveVideoSearchTool.ts
+++ b/src/tools/BraveVideoSearchTool.ts
@@ -56,7 +56,10 @@ export interface VideoSearchOptions extends Pick<BraveSearchOptions, 'country' |
 const videoSearchInputSchema = z.object({
   query: z.string().describe('The term to search the internet for videos of'),
   count: z.number().min(1).max(20).default(10).optional().describe('The number of results to return, minimum 1, maximum 20'),
-  freshness: z.enum(['pd', 'pw', 'pm', 'py'])
+  freshness: z.union([
+    z.enum(['pd', 'pw', 'pm', 'py']),
+    z.string().regex(/^\d{4}-\d{2}-\d{2}to\d{4}-\d{2}-\d{2}$/, 'Date range must be in format YYYY-MM-DDtoYYYY-MM-DD')
+  ])
     .optional()
     .describe(
       `Filters search results by when they were discovered.
@@ -64,7 +67,8 @@ The following values are supported:
 - pd: Discovered within the last 24 hours.
 - pw: Discovered within the last 7 Days.
 - pm: Discovered within the last 31 Days.
-- py: Discovered within the last 365 Days`,
+- py: Discovered within the last 365 Days.
+- YYYY-MM-DDtoYYYY-MM-DD: Custom date range (e.g., 2022-04-01to2022-07-30)`,
     ),
 });
 

--- a/src/tools/BraveWebSearchTool.ts
+++ b/src/tools/BraveWebSearchTool.ts
@@ -8,7 +8,10 @@ const webSearchInputSchema = z.object({
   query: z.string().describe('The term to search the internet for'),
   count: z.number().min(1).max(20).default(10).optional().describe('The number of results to return, minimum 1, maximum 20'),
   offset: z.number().min(0).default(0).optional().describe('The offset for pagination, minimum 0'),
-  freshness: z.enum(['pd', 'pw', 'pm', 'py'])
+  freshness: z.union([
+    z.enum(['pd', 'pw', 'pm', 'py']),
+    z.string().regex(/^\d{4}-\d{2}-\d{2}to\d{4}-\d{2}-\d{2}$/, 'Date range must be in format YYYY-MM-DDtoYYYY-MM-DD')
+  ])
     .optional()
     .describe(
       `Filters search results by when they were discovered.
@@ -16,7 +19,8 @@ The following values are supported:
 - pd: Discovered within the last 24 hours.
 - pw: Discovered within the last 7 Days.
 - pm: Discovered within the last 31 Days.
-- py: Discovered within the last 365 Days`,
+- py: Discovered within the last 365 Days.
+- YYYY-MM-DDtoYYYY-MM-DD: Custom date range (e.g., 2022-04-01to2022-07-30)`,
     ),
 });
 


### PR DESCRIPTION
  - Add support for custom date ranges in web, news, and video search
  - Maintain backward compatibility with existing pd/pw/pm/py values
  - Update README documentation with examples