### PR TITLE
Fix/docker docs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,15 @@
+name: Docker Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build -t brave-search-mcp:test -f apps/brave-search-mcp/Dockerfile .

--- a/README.md
+++ b/README.md
@@ -239,13 +239,19 @@ Replace `YOUR_API_KEY_HERE` with your actual Brave Search API key.
 #### Docker
 
 1. Clone the repo
-2. Docker build
+2. Build the image from the repo root
 
 ```bash
-docker build -t brave-search-mcp:latest -f ./Dockerfile .
+docker build -t brave-search-mcp:latest -f apps/brave-search-mcp/Dockerfile .
 ```
 
-3. Add this to your `claude_desktop_config.json`:
+3. Run it directly if you want HTTP mode:
+
+```bash
+docker run --rm -p 3001:3001 -e BRAVE_API_KEY="YOUR_API_KEY_HERE" brave-search-mcp:latest --http
+```
+
+4. Add this to your `claude_desktop_config.json` for stdio mode:
 
 ```json
 {

--- a/apps/brave-search-mcp/Dockerfile
+++ b/apps/brave-search-mcp/Dockerfile
@@ -1,26 +1,18 @@
-FROM node:23.11-alpine AS builder
+FROM node:23.11-alpine
 
-# Must be entire project because `prepare` script is run during `npm install` and requires all files.
+WORKDIR /app
+
+RUN npm install -g pnpm@10
+
+# Build from the monorepo root so workspace packages resolve correctly.
 COPY . /app
 
-WORKDIR /app
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --no-frozen-lockfile
+RUN pnpm -C apps/brave-search-mcp build
 
-RUN npm install -g pnpm@10
-
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile
-
-FROM node:23.11-alpine AS release
-
-WORKDIR /app
-
-RUN npm install -g pnpm@10
-
-COPY --from=builder /app/dist /app/dist
-COPY --from=builder /app/package.json /app/package.json
-COPY --from=builder /app/pnpm-lock.yaml /app/pnpm-lock.yaml
+WORKDIR /app/apps/brave-search-mcp
 
 ENV NODE_ENV=production
-
-RUN pnpm install --prod --ignore-scripts
+EXPOSE 3001
 
 ENTRYPOINT ["node", "dist/index.js"]

--- a/apps/brave-search-mcp/README.md
+++ b/apps/brave-search-mcp/README.md
@@ -239,13 +239,19 @@ Replace `YOUR_API_KEY_HERE` with your actual Brave Search API key.
 #### Docker
 
 1. Clone the repo
-2. Docker build
+2. Build the image from the repo root
 
 ```bash
-docker build -t brave-search-mcp:latest -f ./Dockerfile .
+docker build -t brave-search-mcp:latest -f apps/brave-search-mcp/Dockerfile .
 ```
 
-3. Add this to your `claude_desktop_config.json`:
+3. Run it directly if you want HTTP mode:
+
+```bash
+docker run --rm -p 3001:3001 -e BRAVE_API_KEY="YOUR_API_KEY_HERE" brave-search-mcp:latest --http
+```
+
+4. Add this to your `claude_desktop_config.json` for stdio mode:
 
 ```json
 {


### PR DESCRIPTION
 ## What this does

  This fixes the Docker instructions in the README and makes sure the image can actually
  be built from this repo.

  The docs were pointing to `./Dockerfile`, but in this repository the Dockerfile lives
  under `apps/brave-search-mcp/`. The existing Dockerfile also wasn't working cleanly
  from the monorepo root, so I updated it to build the app from source in the workspace
  layout.

  I also added a small GitHub Actions workflow to run a basic Docker build on PRs so
  this doesn't drift again.

  ## Changes

  - fix the Docker build command in the root README
  - fix the same Docker section in `apps/brave-search-mcp/README.md`
  - add a simple `docker run` example for HTTP mode
  - update `apps/brave-search-mcp/Dockerfile` to build from the monorepo root
  - add a CI workflow that runs a Docker build on `pull_request`

  ## How I checked it

  I tested the updated flow locally with:

  ```bash
  docker build -t brave-search-mcp:test -f apps/brave-search-mcp/Dockerfile .
  docker run --rm -p 3001:3001 -e BRAVE_API_KEY=test-api-key brave-search-mcp:test
  --http

  The image built successfully and the server came up on http://0.0.0.0:3001/mcp.